### PR TITLE
Update init to import all the initialize.py module

### DIFF
--- a/initialize/__init__.py
+++ b/initialize/__init__.py
@@ -1,0 +1,1 @@
+from .initialize import *


### PR DESCRIPTION
The test in Root_BRIDGES test_init fail to import initialize module on my computer (MacOSX, python 3.12).
I modify the __init__.py

Use 
```
from initialize import MakeScenarios
```